### PR TITLE
set docType default to matroska

### DIFF
--- a/specification.markdown
+++ b/specification.markdown
@@ -395,7 +395,7 @@ Element Name:   DocType
     Mandatory:      Yes
     Multiple:       No
     Range:          -
-    Default:        -
+    Default:        matroska
     Element Type:   String
     Description:    A string that describes the type of document that
                     follows this EBML header.


### PR DESCRIPTION
This patch aligns the EBML spec and matroska spec. Some discussion on this issue is here: http://lists.matroska.org/pipermail/matroska-devel/2015-July/004734.html with @robUx4 opting to set DocType default to matroska to match the matroska spec. Note that with this change, all EBML Header elements would have defaults, meaning that a valid matroska file could simply start with an empty EBML Master-element, such as 0x1A45DFA380 and an EBML parser would presume all default values.

Update: this forum seems to imply that opposite, that EBML's DocType with no defaults is correct and Matroska's spec with a 'matroska' default is wrong. https://bugzilla.mozilla.org/show_bug.cgi?id=778436#c12.

I suggest some discussion and/or review on this PR.