### PR TITLE
allow void element at zero-level

### DIFF
--- a/specification.markdown
+++ b/specification.markdown
@@ -443,7 +443,7 @@ Element Name:   CRC-32
 
 Element Name:   Void
 
-    Level:          1+
+    Level:          0+
     EBML ID:        [EC]
     Mandatory:      No
     Multiple:       No


### PR DESCRIPTION
This resolves a conflict between the EBML and MKV specs. See discussion at http://lists.matroska.org/pipermail/matroska-devel/2015-July/004734.html.