### PR TITLE
Fixed Typo in "Textual expression of Floats"

### DIFF
--- a/specification.markdown
+++ b/specification.markdown
@@ -290,7 +290,7 @@ When a float value is represented textually in an EBML Schema, such as within a 
 | 0.857421875       | 0x1.b7p-1                               |
 | -1.0--0.857421875 | -0x1p+0--0x1.b7p-1                      |
 
-Within an expression of a float range, as in an integer range, the `-` (hyphen) character is the separator between the minimal and maximum value permitted by the range. Note that Hexadecimal Floating-Point Constants also use a `-` (hyphen) when indicating a negative binary power. Within a float range, when a `-` (hyphen) is immediately preceded by a letter `p`, then the `-` (hyphen) is a part of the Hexadecimal Floating-Point Constant which notes negative binary power. Within a float range, when a `-` (hyphen) is immediately preceded by a letter `p`, then the `-` (hyphen) represents the separator between the minimal and maximum value permitted by the range.
+Within an expression of a float range, as in an integer range, the `-` (hyphen) character is the separator between the minimal and maximum value permitted by the range. Note that Hexadecimal Floating-Point Constants also use a `-` (hyphen) when indicating a negative binary power. Within a float range, when a `-` (hyphen) is immediately preceded by a letter `p`, then the `-` (hyphen) is a part of the Hexadecimal Floating-Point Constant which notes negative binary power. Within a float range, when a `-` (hyphen) is not immediately preceded by a letter `p`, then the `-` (hyphen) represents the separator between the minimal and maximum value permitted by the range.
 
 #### Note on the Use of default attributes to define Mandatory EBML Elements
 


### PR DESCRIPTION
Fixed a typo regarding the meaning of '-' character in float range.