### PR TITLE
remove unclear parenthetical fragment

### DIFF
--- a/signature.markdown
+++ b/signature.markdown
@@ -67,7 +67,7 @@ Element Name:   Signature
     Range:          -
     Default:        -
     Element Type:   Binary
-    Description:    The signature of the data (until a new.
+    Description:    The signature of the data.
 
 Element Name:   SignatureElements
 


### PR DESCRIPTION
partial fix for https://github.com/Matroska-Org/ebml-specification/issues/77. I checked the wayback machine and Signature has never appeared to have a more complete definition. The webM version of the definition is also fragmentary. This fixes the typo but leaves the issue of the element still being very unclear.