### PR TITLE
gives grammatical consistency to definitions list in Section 2

### DIFF
--- a/specification.markdown
+++ b/specification.markdown
@@ -14,19 +14,19 @@ This document defines specific terms in order to define the format and applicati
 
 `EBML`: Extensible Binary Meta Language
 
-`EBML Document Type`: An `EBML Document Type` is a name provided by an `EBML Schema` for a particular implementation of `EBML` for a data format (examples: matroska and webm).
+`EBML Document Type`: A name provided by an `EBML Schema` to designate a particular implementation of `EBML` for a data format (e.g.: matroska and webm).
 
 `EBML Schema`: A standardized definition for the structure of an `EBML Document Type`.
 
-`EBML Document`: An `EBML Document` is a datastream comprised of only two components, an `EBML Header` and an `EBML Body`.
+`EBML Document`: A datastream comprised of only two components, an `EBML Header` and an `EBML Body`.
 
-`EBML Reader`: An `EBML Reader` is a data parser that interprets the semantics of an `EBML Document` and creates a way for programs to use `EBML`.
+`EBML Reader`: A data parser that interprets the semantics of an `EBML Document` and creates a way for programs to use `EBML`.
 
-`EBML Stream`: An `EBML Stream` is a file that consists of one or more `EBML Documents` that are concatenated together.
+`EBML Stream`: A file that consists of one or more `EBML Documents` that are concatenated together.
 
-`EBML Header`: The `EBML Header` is a declaration that provides processing instructions and identification of the `EBML Body`. The `EBML Header` may be considered as analogous to an XML Declaration [@!W3C.REC-xml-20081126] (see section 2.8 on Prolog and Document Type Declaration).
+`EBML Header`: A declaration that provides processing instructions and identification of the `EBML Body`. The `EBML Header` may be considered as analogous to an XML Declaration [@!W3C.REC-xml-20081126] (see section 2.8 on Prolog and Document Type Declaration).
 
-`EBML Body`: All data of an `EBML Document` following the `EBML Header` may be considered the `EBML Body`.
+`EBML Body`: All data of an `EBML Document` following the `EBML Header`.
 
 `Variable Size Integer`: A compact variable-length binary value which defines its own length.
 
@@ -58,13 +58,13 @@ This document defines specific terms in order to define the format and applicati
 
 `Parent Element`: A relative term to describe the `Master Element` which contains a specified element. For any specified `EBML Element` that is not at `Root Level`, the `Parent Element` refers to the `Master Element` in which that `EBML Element` is contained.
 
-`Descendant Element`: A `Descendant Element` is a relative term to describe any `EBML Elements` contained within a `Master Element`, including any of the `Child Elements` of its `Child Elements`, and so on.
+`Descendant Element`: A relative term to describe any `EBML Elements` contained within a `Master Element`, including any of the `Child Elements` of its `Child Elements`, and so on.
 
 `Element Name`: The official human-readable name of the `EBML Element`.
 
 `Element Path`: The hierarchy of `Parent Element` where the `EBML Element` is expected to be found in the `EBML Body`.
 
-`Empty Element`: An `Empty Element` is an `EBML Element` that has an `Element Data Size` with all `VINT_DATA` bits set to zero which indicates that the `Element Data` of the Element is zero octets in length.
+`Empty Element`: An `EBML Element` that has an `Element Data Size` with all `VINT_DATA` bits set to zero, which indicates that the `Element Data` of the `Element` is zero octets in length.
 
 # Security Considerations
 
@@ -289,7 +289,7 @@ This method is only RECOMMENDED for reducing `Element Data` by a single octet; f
 
 Note that if the `Element Data` length needs to be rewritten as shortened by one octet and the `Element Data Size` could be rewritten as a shorter `VINT` then it is RECOMMENDED to rewrite the `Element Data Size` as one octet shorter, shorten the `Element Data` by one octet, and follow that `Element` with a `Void Element`. For example, the following table depicts a `String Element` that stores an `Element ID` (3 octets), `Element Data Size` (2 octets, but could be rewritten in one octet), and `Element Data` (3 octets). If the `Element Data` is to be rewritten to a two octet length, then another octet can be taken from `Element Data Size` so that there is enough space to add a two octet `Void Element`.
 
-Status | Element ID | Element Data Size | Element Data | Void Element 
+Status | Element ID | Element Data Size | Element Data | Void Element
 -------|------------|-------------------|--------------|-------------
 Before | 0x3B4040   | 0x4003            | 0x6d6b76     |
 After  | 0x3B4040   | 0x82              | 0x6869       | 0xEC80


### PR DESCRIPTION
This has come up before, maybe in matroska-specification, in how to handle definitions. This PR updates the definitions so they all follow the same pattern and do not repeat the word being defined within the definition.