### PR TITLE
add DocTypeExtension to handle experimental elements and regular extensions

### DIFF
--- a/specification.markdown
+++ b/specification.markdown
@@ -749,6 +749,56 @@ type: Unsigned Integer
 
 description: The minimum `DocType` version an `EBML Reader` has to support to read this `EBML Document`. The value of the `DocTypeReadVersion Element` MUST be less than or equal to the value of the `DocTypeVersion Element`.
 
+### DocTypeExtension Element
+
+name: `DocTypeExtension`
+
+path: `0*(\EBML\DocTypeExtension)`
+
+id `0x4281`
+
+minOccurs: 0
+
+type: `Master Element`
+
+description: A `DocType` extension adds extra `Elements` to the main `DocType`+`DocTypeVersion` it's attached to. An `EBML Reader` MAY understand these extra `Elements`. It can be used to iterate between experimental `Elements` before they are integrated in a regular `DocTypeVersion`. Reading one `DocTypeExtension` version of a `DocType`+`DocTypeVersion` doesn't imply one should be able to read upper values of this `DocTypeExtension`.
+
+### ExtensionName Element
+
+name: `ExtensionName`
+
+path: `1*1(\EBML\DocTypeExtension\ExtensionName)`
+
+id `0x4283`
+
+minOccurs: 1
+
+maxOccurs: 1
+
+size: >0
+
+type: String
+
+description: The name of the `DocTypeExtension` to uniquely identify it from other `DocTypeExtension` of the same `DocType`+`DocTypeVersion`.
+
+### ExtensionVersion Element
+
+name: `ExtensionVersion`
+
+path: `1*1(\EBML\DocTypeExtension\ExtensionVersion)`
+
+id `0x4284`
+
+minOccurs: 1
+
+maxOccurs: 1
+
+range: not 0
+
+type: Unsigned Integer
+
+description: The version of the `DocTypeExtension`. Different `ExtensionVersion` values of the same `DocType`+`DocTypeVersion`+`ExtensionName` tuple MAY contain completely different sets of extra `Elements`. And `EBML Reader` MAY support mutiple versions of the same `DocTypeExtension`, only one or none.
+
 ## Global Elements
 
 EBML defines these `Global Elements` which MAY be stored within any `Master Element` of an `EBML Document` as defined by their `Element Path`.

--- a/specification.markdown
+++ b/specification.markdown
@@ -797,7 +797,7 @@ range: not 0
 
 type: Unsigned Integer
 
-description: The version of the `DocTypeExtension`. Different `DocTypeExtensionVersion` values of the same `DocType`+`DocTypeVersion`+`DocTypeExtensionName` tuple MAY contain completely different sets of extra `Elements`. And `EBML Reader` MAY support multiple versions of the same `DocTypeExtension`, only one or none.
+description: The version of the `DocTypeExtension`. Different `DocTypeExtensionVersion` values of the same `DocType`+`DocTypeVersion`+`DocTypeExtensionName` tuple MAY contain completely different sets of extra `Elements`. An `EBML Reader` MAY support multiple versions of the same `DocTypeExtension`, only one or none.
 
 ## Global Elements
 

--- a/specification.markdown
+++ b/specification.markdown
@@ -887,6 +887,9 @@ ID Values found in this document are assigned as initial values as follows:
 0x4282     | DocType             | Described in [section DocType](#doctype-element)
 0x4287     | DocTypeVersion      | Described in [section DocTypeVersion](#doctypeversion-element)
 0x4285     | DocTypeReadVersion  | Described in [section DocTypeReadVersion](#doctypereadversion-element)
+0x4281     | DocTypeExtension    | Described in [section DocTypeExtension](#doctypeextension-element)
+0x4283     | ExtensionName       | Described in [section ExtensionName](#extensionname-element)
+0x4284     | ExtensionVersion    | Described in [section ExtensionVersion](#extensionversion-element)
 0xBF       | CRC-32              | Described in [section CRC-32](#crc32-element)
 0xEC       | Void                | Described in [section Void](#void-element)
 

--- a/specification.markdown
+++ b/specification.markdown
@@ -761,7 +761,7 @@ minOccurs: 0
 
 type: `Master Element`
 
-description: A `DocType` extension adds extra `Elements` to the main `DocType`+`DocTypeVersion` it's attached to. An `EBML Reader` MAY understand these extra `Elements`. It MAY be used to iterate between experimental `Elements` before they are integrated in a regular `DocTypeVersion`. Reading one `DocTypeExtension` version of a `DocType`+`DocTypeVersion` doesn't imply one should be able to read upper values of this `DocTypeExtension`.
+description: A `DocType` extension adds extra `Elements` to the main `DocType`+`DocTypeVersion` tuple it's attached to. An `EBML Reader` MAY understand these extra `Elements`. It MAY be used to iterate between experimental `Elements` before they are integrated in a regular `DocTypeVersion`. Reading one `DocTypeExtension` version of a `DocType`+`DocTypeVersion` tuple doesn't imply one should be able to read upper values of this `DocTypeExtension`.
 
 ### ExtensionName Element
 
@@ -779,7 +779,7 @@ size: >0
 
 type: String
 
-description: The name of the `DocTypeExtension` to uniquely identify it from other `DocTypeExtension` of the same `DocType`+`DocTypeVersion`.
+description: The name of the `DocTypeExtension` to uniquely identify it from other `DocTypeExtension` of the same `DocType`+`DocTypeVersion` tuple.
 
 ### ExtensionVersion Element
 
@@ -797,7 +797,7 @@ range: not 0
 
 type: Unsigned Integer
 
-description: The version of the `DocTypeExtension`. Different `ExtensionVersion` values of the same `DocType`+`DocTypeVersion`+`ExtensionName` tuple MAY contain completely different sets of extra `Elements`. And `EBML Reader` MAY support mutiple versions of the same `DocTypeExtension`, only one or none.
+description: The version of the `DocTypeExtension`. Different `ExtensionVersion` values of the same `DocType`+`DocTypeVersion`+`ExtensionName` tuple MAY contain completely different sets of extra `Elements`. And `EBML Reader` MAY support multiple versions of the same `DocTypeExtension`, only one or none.
 
 ## Global Elements
 

--- a/specification.markdown
+++ b/specification.markdown
@@ -763,11 +763,11 @@ type: `Master Element`
 
 description: A `DocTypeExtension` adds extra `Elements` to the main `DocType`+`DocTypeVersion` tuple it's attached to. An `EBML Reader` MAY understand these extra `Elements`. A `DocTypeExtension` MAY be used to iterate between experimental `Elements` before they are integrated in a regular `DocTypeVersion`. Reading one `DocTypeExtension` version of a `DocType`+`DocTypeVersion` tuple doesn't imply one should be able to read upper values of this `DocTypeExtension`.
 
-### ExtensionName Element
+### DocTypeExtensionName Element
 
-name: `ExtensionName`
+name: `DocTypeExtensionName`
 
-path: `1*1(\EBML\DocTypeExtension\ExtensionName)`
+path: `1*1(\EBML\DocTypeExtension\Name)`
 
 id `0x4283`
 
@@ -781,11 +781,11 @@ type: String
 
 description: The name of the `DocTypeExtension` to uniquely identify it from other `DocTypeExtension` of the same `DocType`+`DocTypeVersion` tuple.
 
-### ExtensionVersion Element
+### DocTypeExtensionVersion Element
 
-name: `ExtensionVersion`
+name: `DocTypeExtensionVersion`
 
-path: `1*1(\EBML\DocTypeExtension\ExtensionVersion)`
+path: `1*1(\EBML\DocTypeExtension\Version)`
 
 id `0x4284`
 
@@ -797,7 +797,7 @@ range: not 0
 
 type: Unsigned Integer
 
-description: The version of the `DocTypeExtension`. Different `ExtensionVersion` values of the same `DocType`+`DocTypeVersion`+`ExtensionName` tuple MAY contain completely different sets of extra `Elements`. And `EBML Reader` MAY support multiple versions of the same `DocTypeExtension`, only one or none.
+description: The version of the `DocTypeExtension`. Different `DocTypeExtensionVersion` values of the same `DocType`+`DocTypeVersion`+`DocTypeExtensionName` tuple MAY contain completely different sets of extra `Elements`. And `EBML Reader` MAY support multiple versions of the same `DocTypeExtension`, only one or none.
 
 ## Global Elements
 
@@ -877,21 +877,21 @@ Five octet Element IDs (values from 0x10000001 upwards) are reserved for Experim
 
 ID Values found in this document are assigned as initial values as follows:
 
- ID        | Element Name        | Reference
-----------:|:--------------------|:-------------------------------------------
-0x1A45DFA3 | EBML                | Described in [section EBML](#ebml-element)
-0x4286     | EBMLVersion         | Described in [section EBMLVersion](#ebmlversion-element)
-0x42F7     | EBMLReadVersion     | Described in [section EBMLReadVersion](#ebmlreadversion-element)
-0x42F2     | EBMLMaxIDLength     | Described in [section EBMLMaxIDLength](#ebmlmaxidlength-element)
-0x42F3     | EBMLMaxSizeLength   | Described in [section EBMLMaxSizeLength](#ebmlmaxsizelength-element)
-0x4282     | DocType             | Described in [section DocType](#doctype-element)
-0x4287     | DocTypeVersion      | Described in [section DocTypeVersion](#doctypeversion-element)
-0x4285     | DocTypeReadVersion  | Described in [section DocTypeReadVersion](#doctypereadversion-element)
-0x4281     | DocTypeExtension    | Described in [section DocTypeExtension](#doctypeextension-element)
-0x4283     | ExtensionName       | Described in [section ExtensionName](#extensionname-element)
-0x4284     | ExtensionVersion    | Described in [section ExtensionVersion](#extensionversion-element)
-0xBF       | CRC-32              | Described in [section CRC-32](#crc32-element)
-0xEC       | Void                | Described in [section Void](#void-element)
+ ID        | Element Name            | Reference
+----------:|:------------------------|:-------------------------------------------
+0x1A45DFA3 | EBML                    | Described in [section EBML](#ebml-element)
+0x4286     | EBMLVersion             | Described in [section EBMLVersion](#ebmlversion-element)
+0x42F7     | EBMLReadVersion         | Described in [section EBMLReadVersion](#ebmlreadversion-element)
+0x42F2     | EBMLMaxIDLength         | Described in [section EBMLMaxIDLength](#ebmlmaxidlength-element)
+0x42F3     | EBMLMaxSizeLength       | Described in [section EBMLMaxSizeLength](#ebmlmaxsizelength-element)
+0x4282     | DocType                 | Described in [section DocType](#doctype-element)
+0x4287     | DocTypeVersion          | Described in [section DocTypeVersion](#doctypeversion-element)
+0x4285     | DocTypeReadVersion      | Described in [section DocTypeReadVersion](#doctypereadversion-element)
+0x4281     | DocTypeExtension        | Described in [section DocTypeExtension](#doctypeextension-element)
+0x4283     | DocTypeExtensionName    | Described in [section DocTypeExtensionName](#doctypeextensionname-element)
+0x4284     | DocTypeExtensionVersion | Described in [section DocTypeExtensionVersion](#doctypeextensionversion-element)
+0xBF       | CRC-32                  | Described in [section CRC-32](#crc32-element)
+0xEC       | Void                    | Described in [section Void](#void-element)
 
 ## CELLAR EBML DocType Registry
 

--- a/specification.markdown
+++ b/specification.markdown
@@ -779,7 +779,7 @@ size: >0
 
 type: String
 
-description: The name of the `DocTypeExtension` to uniquely identify it from other `DocTypeExtension` of the same `DocType`+`DocTypeVersion` tuple.
+description: The name of the `DocTypeExtension` to identify it from other `DocTypeExtension` of the same `DocType`+`DocTypeVersion` tuple.
 
 ### DocTypeExtensionVersion Element
 

--- a/specification.markdown
+++ b/specification.markdown
@@ -761,7 +761,7 @@ minOccurs: 0
 
 type: `Master Element`
 
-description: A `DocType` extension adds extra `Elements` to the main `DocType`+`DocTypeVersion` it's attached to. An `EBML Reader` MAY understand these extra `Elements`. It can be used to iterate between experimental `Elements` before they are integrated in a regular `DocTypeVersion`. Reading one `DocTypeExtension` version of a `DocType`+`DocTypeVersion` doesn't imply one should be able to read upper values of this `DocTypeExtension`.
+description: A `DocType` extension adds extra `Elements` to the main `DocType`+`DocTypeVersion` it's attached to. An `EBML Reader` MAY understand these extra `Elements`. It MAY be used to iterate between experimental `Elements` before they are integrated in a regular `DocTypeVersion`. Reading one `DocTypeExtension` version of a `DocType`+`DocTypeVersion` doesn't imply one should be able to read upper values of this `DocTypeExtension`.
 
 ### ExtensionName Element
 

--- a/specification.markdown
+++ b/specification.markdown
@@ -761,7 +761,7 @@ minOccurs: 0
 
 type: `Master Element`
 
-description: A `DocType` extension adds extra `Elements` to the main `DocType`+`DocTypeVersion` tuple it's attached to. An `EBML Reader` MAY understand these extra `Elements`. It MAY be used to iterate between experimental `Elements` before they are integrated in a regular `DocTypeVersion`. Reading one `DocTypeExtension` version of a `DocType`+`DocTypeVersion` tuple doesn't imply one should be able to read upper values of this `DocTypeExtension`.
+description: A `DocTypeExtension` adds extra `Elements` to the main `DocType`+`DocTypeVersion` tuple it's attached to. An `EBML Reader` MAY understand these extra `Elements`. A `DocTypeExtension` MAY be used to iterate between experimental `Elements` before they are integrated in a regular `DocTypeVersion`. Reading one `DocTypeExtension` version of a `DocType`+`DocTypeVersion` tuple doesn't imply one should be able to read upper values of this `DocTypeExtension`.
 
 ### ExtensionName Element
 


### PR DESCRIPTION
This is an alternative proposal from #180 allowing more flexibility