### PR TITLE
rename bytes to octets to match the rest of the specs

### DIFF
--- a/specification.markdown
+++ b/specification.markdown
@@ -783,24 +783,24 @@ description: Used to void damaged data, to avoid unexpected behaviors when using
 
 This document creates a new IANA Registry called "CELLAR EBML Element ID Registry".
 
-Element IDs are described in section `Element ID`.  Element IDs are encoded using the VINT mechanism described in section (#variable-size-integer) can be between one and five bytes long. Five byte long Element IDs are possible only if declared in the header.
+Element IDs are described in section `Element ID`.  Element IDs are encoded using the VINT mechanism described in section (#variable-size-integer) can be between one and five octets long. Five octet long Element IDs are possible only if declared in the header.
 
-The VINT Data value of one-byte Element IDs MUST be between 0x01 and 0x7E. These items are valuable because they are short, and need to be used for commonly repeated elements. Values from 1 to 126 are to be allocated according to RFC Required.
+The VINT Data value of one-octet Element IDs MUST be between 0x01 and 0x7E. These items are valuable because they are short, and need to be used for commonly repeated elements. Values from 1 to 126 are to be allocated according to RFC Required.
 
-The VINT Data value of two-byte Element IDs MUST be between 0x007F and 0x3FFE. Numbers MAY be allocated within this range according to Specification Required.
+The VINT Data value of two-octet Element IDs MUST be between 0x007F and 0x3FFE. Numbers MAY be allocated within this range according to Specification Required.
 
 The numbers 0x3FFF and 0x4000 are RESERVED.
 
-The VINT Data value of three-byte Element IDs MUST be between 0x4001 and 0x1FFFFE. Numbers may be allocated within this range according to First Come First Served (see [@!RFC8126])
+The VINT Data value of three-octet Element IDs MUST be between 0x4001 and 0x1FFFFE. Numbers may be allocated within this range according to First Come First Served (see [@!RFC8126])
 
 The numbers 0x1FFFFF and 0x200000 are RESERVED.
 
-Four byte Element IDs are numbers between 0x2000001 and 0xFFFFFFE. Four byte Element IDs are somewhat special in that they are useful for resynchronizing to major structures in the event of data corruption or loss.  As such four byte Element IDs are split into two categories.  Four byte Element IDs whose lower three bytes (as encoded) would make printable 7-bit ASCII values may be allocated only Specification Required.  Sequential allocation of values is not required: specifications SHOULD include a specific request, and are encouraged to do early allocations.
+Four octet Element IDs are numbers between 0x2000001 and 0xFFFFFFE. Four octet Element IDs are somewhat special in that they are useful for resynchronizing to major structures in the event of data corruption or loss.  As such four octet Element IDs are split into two categories.  Four octet Element IDs whose lower three octets (as encoded) would make printable 7-bit ASCII values may be allocated only Specification Required.  Sequential allocation of values is not required: specifications SHOULD include a specific request, and are encouraged to do early allocations.
 
-To be clear about the above category: Four Byte Element IDs always start with hex 0x10 to 0x1F,  and that byte may be chosen so that the entire number has some desirable property, such as a specific CRC.  The other three bytes, when ALL having values between 0x21 (33, ASCII !) and 0x7e (126, ASCII ~), fall into this catgory.
+To be clear about the above category: Four Octet Element IDs always start with hex 0x10 to 0x1F,  and that octet may be chosen so that the entire number has some desirable property, such as a specific CRC.  The other three octets, when ALL having values between 0x21 (33, ASCII !) and 0x7e (126, ASCII ~), fall into this catgory.
 
-Other Four Byte Element IDs may be allocated by First Come First Served (see [@!RFC8126]).
+Other Four Octet Element IDs may be allocated by First Come First Served (see [@!RFC8126]).
 
 The numbers 0xFFFFFFF and 0x1000000 are RESERVED.
 
-Five Byte Element IDs (values from 0x10000001 upwards) are reserved for Experimental use: they may be used by anyone at any time, but there is no coordination.
+Five Octet Element IDs (values from 0x10000001 upwards) are reserved for Experimental use: they may be used by anyone at any time, but there is no coordination.


### PR DESCRIPTION
Since that's what we used everywhere. It's also clearer than byte, which may (mostly in the past) represent more than 8 bits.