### PR TITLE
Fix table showing the number of IDs in each EBML Class

### DIFF
--- a/specification.markdown
+++ b/specification.markdown
@@ -134,10 +134,10 @@ The octet length of an `Element ID` determines its `EBML Class`.
 
 EBML Class | Octet Length | Number of Possible Element IDs
 :---------:|:------------:|:------------------------------
-Class A    | 1            | 2^7  - 2        =         126
-Class B    | 2            | 2^14 - 2^7  - 1 =      16,255
-Class C    | 3            | 2^21 - 2^14 - 1 =   2,080,767
-Class D    | 4            | 2^28 - 2^21 - 1 = 266,338,303
+Class A    | 1            | 2^7  - 2    =         126
+Class B    | 2            | 2^14 - 2^7  =      16,256
+Class C    | 3            | 2^21 - 2^14 =   2,080,768
+Class D    | 4            | 2^28 - 2^21 = 266,338,304
 
 # Element Data Size
 


### PR DESCRIPTION
The table is currently wrong: The valid IDs in class B correspond to the VINT_DATA in the range of 2^7 - 1 to 2^14 - 2 (inclusive) so that there are 2^14 - 2 - (2^7 - 1) + 1 = 2^14 - 2^7 of them; it's similar for the other classes apart from A.

Notice that the current numbers can't be explained with 0x3FFF and 0x4000 etc. being reserved, because then the formulae were still wrong (it would need -2 for class C and D, too, instead of just for class A) and because they are only reserved for the header (and if they were reserved everywhere, then this would need to be mentioned in the section about EBML IDs, because otherwise the table would be unintelligible).

I could have written the amount in the form 2^14 - 2 - (2^7 - 1) + 1, but this would probably wrap, so I didn't do it. 