### PR TITLE
Escape "*"

### DIFF
--- a/specification.markdown
+++ b/specification.markdown
@@ -160,7 +160,7 @@ Octet Length | Possible Value Range
 7            | 0 to 2^49-2
 8            | 0 to 2^56-2
 
-If the length of `Element Data` equals `2^(n*7)-1` then the octet length of the `Element Data Size` MUST be at least `n+1`. This rule prevents an `Element Data Size` from being expressed as a reserved value. The following table clarifies this rule by showing a valid and invalid expression of an `Element Data Size` with a `VINT_DATA` of 127 (which is equal to 2^(1*7)-1) and 16,383 (which is equal to 2^(2*7)-1).
+If the length of `Element Data` equals 2^(n\*7)-1 then the octet length of the `Element Data Size` MUST be at least `n+1`. This rule prevents an `Element Data Size` from being expressed as a reserved value. The following table clarifies this rule by showing a valid and invalid expression of an `Element Data Size` with a `VINT_DATA` of 127 (which is equal to 2^(1\*7)-1) and 16,383 (which is equal to 2^(2\*7)-1).
 
 VINT_WIDTH  | VINT_MARKER  | VINT_DATA             | Element Data Size Status
 -----------:|-------------:|----------------------:|---------------------------


### PR DESCRIPTION
This is done in order to distinguish "*" (the multiplication sign) from being interpreted as emphasis by markdown. Addresses one of the issues raised in Robert Sparks' review.

This commit also unbackticks two other formulae (one very similar to this one) to bring them into line with other formulae.

I don't know if formulae should be backticked or not; the relevant part of #226 is wrong.
