### PR TITLE
rename EBMLReferencePath to EBMLMasterPath so the path definition fits in72 cols

### DIFF
--- a/specification.markdown
+++ b/specification.markdown
@@ -216,7 +216,7 @@ The `Date Element` stores an integer in the same format as the `Signed Integer E
 
 A `Master Element` MUST declare a length in octets from zero to `VINTMAX`. The `Master Element` MAY also use an unknown length. See [the section on `Element Data Size`](#element-data-size) for rules that apply to elements of unknown length.
 
-The `Master Element` contains zero, one, or many other elements. `EBML Elements` contained within a `Master Element` MUST have the `EBMLParentPath` of their `Element Path` equals to the `EBMLReferencePath` of the `Master Element` `Element Path` (see [the section on the `EBML Path`](#path)). `Element Data` stored within `Master Elements` SHOULD only consist of `EBML Elements` and SHOULD NOT contain any data that is not part of an `EBML Element`. When `EBML` is used in transmission or streaming, data that is not part of an `EBML Element` is permitted to be present within a `Master Element` if `unknownsizeallowed` is enabled within the definition for that `Master Element`. In this case, the `EBML Reader` should skip data until a valid `Element ID` of the same `EBMLParentPath` or the next upper level `Element Path` of the `Master Element` is found. The `EBML Schema` identifies what `Element IDs` are valid within the `Master Elements` for that version of the `EBML Document Type`. Any data contained within a `Master Element` that is not part of a `Child Element` MUST be ignored.
+The `Master Element` contains zero, one, or many other elements. `EBML Elements` contained within a `Master Element` MUST have the `EBMLParentPath` of their `Element Path` equals to the `EBMLMasterPath` of the `Master Element` `Element Path` (see [the section on the `EBML Path`](#path)). `Element Data` stored within `Master Elements` SHOULD only consist of `EBML Elements` and SHOULD NOT contain any data that is not part of an `EBML Element`. When `EBML` is used in transmission or streaming, data that is not part of an `EBML Element` is permitted to be present within a `Master Element` if `unknownsizeallowed` is enabled within the definition for that `Master Element`. In this case, the `EBML Reader` should skip data until a valid `Element ID` of the same `EBMLParentPath` or the next upper level `Element Path` of the `Master Element` is found. The `EBML Schema` identifies what `Element IDs` are valid within the `Master Elements` for that version of the `EBML Document Type`. Any data contained within a `Master Element` that is not part of a `Child Element` MUST be ignored.
 
 ## Binary Element
 
@@ -377,8 +377,8 @@ The path defines the allowed storage locations of the `EBML Element` within an `
 The `path` attribute is REQUIRED.
 
 ```
-EBMLFullPath             = EBMLElementOccurrence "(" EBMLReferencePath ")"
-EBMLReferencePath        = [EBMLParentPath] EBMLElementPath
+EBMLFullPath             = EBMLElementOccurrence "(" EBMLMasterPath ")"
+EBMLMasterPath           = [EBMLParentPath] EBMLElementPath
 EBMLParentPath           = EBMLFixedParent EBMLLastParent
 EBMLFixedParent          = *(EBMLPathAtom)
 EBMLElementPath          = EBMLPathAtom / EBMLPathAtomRecursive


### PR DESCRIPTION
It also makes it easier to link the parent part to the master patch