### PR TITLE
make sure the EBML Body doesn't use 0x1A45DFA3

### DIFF
--- a/specification.markdown
+++ b/specification.markdown
@@ -328,6 +328,8 @@ An `EBML Schema` MUST declare exactly one `EBML Element` at `Root Level` (referr
 
 The `EBML Schema` MUST document all Elements of the `EBML Body`. The `EBML Schema` does not document `Global Elements` that are defined by this document (namely the `Void Element` and the `CRC-32 Element`).
 
+The EBML Schema` MUST NOT use the Element ID `0x1A45DFA3` which is reserved for the EBML Header for resynchronization purpose.
+
 An `EBML Schema` MAY constrain the use of `EBML Header Elements` (see [EBML Header Elements](#ebml-header-elements)) by adding or constraining that Element's `range` attribute. For example, an `EBML Schema` MAY constrain the `EBMLMaxSizeLength` to a maximum value of `8` or MAY constrain the `EBMLVersion` to only support a value of `1`. If an `EBML Schema` adopts the `EBML Header Element` as-is, then it is not required to document that Element within the `EBML Schema`. If an `EBML Schema` constrains the range of an `EBML Header Element`, then that `Element` MUST be documented within an `<element>` node of the `EBML Schema`. This document provides an example of an `EBML Schema`, see [EBML Schema Example](#ebml-schema-example).
 
 ### EBML Schema Example


### PR DESCRIPTION
As discussed on the ML, IDs from the header can be reused in a format (it's not nice but not forbidden). But the 0x1A45DFA3 which is the `EBML Header` master element MUST NOT be used as a top level ID. And since that's for resynchronization it should not be used at any level for more safety.